### PR TITLE
Use 'use x' instead of 'use namespace x'

### DIFF
--- a/Assert.osp
+++ b/Assert.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace aves.reflection;
+use aves;
+use aves.reflection;
 
 namespace testing.unit;
 

--- a/AssertionMessages.osp
+++ b/AssertionMessages.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace testing.unit;
 

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ To define a test fixture, declare a class that derives from the abstract class `
 Then, define your tests as methods on the test fixture class. Every public instance method whose name begins with “`test_`” is part of the test fixture, and like the constructor, must accept zero arguments. An example follows.
 
 ```
-use namespace aves;
-use namespace testing.unit;
+use aves;
+use testing.unit;
 
 namespace my.module.test;
 
@@ -72,8 +72,8 @@ The class `testing.unit.TestFixture` also has a public static method `runAll`, w
 Running a module full of test fixtures usually involves no more than this bit of code:
 
 ```
-use namespace aves.reflection; // for Module
-use namespace testing.unit;
+use aves.reflection; // for Module
+use testing.unit;
 
 TestFixture.runAll(Module.getCurrentModule());
 ```

--- a/TestFixture.osp
+++ b/TestFixture.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace aves.reflection;
+use aves;
+use aves.reflection;
 
 namespace testing.unit;
 

--- a/TestResult.osp
+++ b/TestResult.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 use Method = aves.reflection.Method;
 
 namespace testing.unit;

--- a/TestResultPrinter.osp
+++ b/TestResultPrinter.osp
@@ -1,4 +1,4 @@
-use namespace aves;
+use aves;
 
 namespace testing.unit;
 

--- a/TestRunner.osp
+++ b/TestRunner.osp
@@ -1,5 +1,5 @@
-use namespace aves;
-use namespace aves.reflection;
+use aves;
+use aves.reflection;
 
 namespace testing.unit;
 


### PR DESCRIPTION
osprey-lang/ospc#1 and osprey-lang/osprey#1 change the 'use namespace x' syntax to just 'use x', which naturally breaks a lot of source files. Update source files.